### PR TITLE
fix #26 by using RNGCryptoServiceProvider on net45

### DIFF
--- a/src/Microsoft.AspNet.WebSockets.Protocol/CommonWebSocket.cs
+++ b/src/Microsoft.AspNet.WebSockets.Protocol/CommonWebSocket.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Net.WebSockets;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ namespace Microsoft.AspNet.WebSockets.Protocol
     public class CommonWebSocket : WebSocket
     {
         private readonly static byte[] PingBuffer = Encoding.ASCII.GetBytes("abcdefghijklmnopqrstuvwxyz");
+        private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
 
         private readonly Stream _stream;
         private readonly string _subProtocl;
@@ -100,10 +102,6 @@ namespace Microsoft.AspNet.WebSockets.Protocol
         // the bytes that appear on the wire.  RFC 4086 [RFC4086] discusses what
         // entails a suitable source of entropy for security-sensitive
         // applications.
-#if NET45
-        // Normally we don't group methods and fields like this but I want to centralize the #if :)
-        // Same for using full namespace names.
-        private static readonly System.Security.Cryptography.RandomNumberGenerator _rng = new System.Security.Cryptography.RNGCryptoServiceProvider();
         private int GetNextMask()
         {
             if (_useZeroMask)
@@ -116,12 +114,6 @@ namespace Microsoft.AspNet.WebSockets.Protocol
             _rng.GetBytes(buffer);
             return BitConverter.ToInt32(buffer, 0);
         }
-#else
-        private int GetNextMask()
-        {
-            throw new PlatformNotSupportedException("The WebSocket client is not supported on this platform.");
-        }
-#endif
 
         public override async Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
         {

--- a/src/Microsoft.AspNet.WebSockets.Protocol/CommonWebSocket.cs
+++ b/src/Microsoft.AspNet.WebSockets.Protocol/CommonWebSocket.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Net.WebSockets;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,7 +102,8 @@ namespace Microsoft.AspNet.WebSockets.Protocol
         // applications.
 #if NET45
         // Normally we don't group methods and fields like this but I want to centralize the #if :)
-        private static readonly RandomNumberGenerator _rng = new RNGCryptoServiceProvider();
+        // Same for using full namespace names.
+        private static readonly System.Security.Cryptography.RandomNumberGenerator _rng = new System.Security.Cryptography.RNGCryptoServiceProvider();
         private int GetNextMask()
         {
             if (_useZeroMask)

--- a/src/Microsoft.AspNet.WebSockets.Protocol/project.json
+++ b/src/Microsoft.AspNet.WebSockets.Protocol/project.json
@@ -18,6 +18,7 @@
                 "System.Security.Cryptography.Encryption": "4.0.0-beta-*",
                 "System.Security.Cryptography.Hashing": "4.0.0-beta-*",
                 "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-*",
+                "System.Security.Cryptography.RandomNumberGenerator": "4.0.0-beta-*",
                 "System.Text.Encoding.Extensions": "4.0.10-beta-*",
                 "System.Threading": "4.0.10-beta-*",
                 "System.Threading.Tasks": "4.0.10-beta-*",


### PR DESCRIPTION
We'll still be using the System.Random generator on CoreCLR unfortunately since there isn't an implementation of RNGCryptoServiceProvider on CoreCLR

Fixes #26 

/cc @Tratcher @blowdart 