### PR TITLE
Update AutobahnTestServer to use IISIntegration

### DIFF
--- a/test/AutobahnTestServer/Startup.cs
+++ b/test/AutobahnTestServer/Startup.cs
@@ -74,6 +74,7 @@ namespace AutobahnTestServer
         {
             var host = new WebHostBuilder()
                 .UseKestrel()
+                .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();
 

--- a/test/AutobahnTestServer/project.json
+++ b/test/AutobahnTestServer/project.json
@@ -1,8 +1,8 @@
 {
-  "exclude": "wwwroot/**/*",
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Microsoft.AspNetCore.WebSockets.Server": "0.1.0-*",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*"
   },
   "buildOptions": {
@@ -27,7 +27,16 @@
   },
   "publishOptions": {
     "include": [
-      "hosting.json"
+      "web.config"
     ]
+  },
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
+      "version": "1.0.0-*",
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
+    }
+  },
+  "scripts": {
+    "postpublish": "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%"
   }
 }

--- a/test/AutobahnTestServer/web.config
+++ b/test/AutobahnTestServer/web.config
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
@Tratcher I am updating the autobahn server to use IISIntegration since it was needed as a test sample for IIS on nano. Since I don't see any downsides to having this change in our repo, I was thinking we can just take them for the dev branch. This is currently on release since that's what needs to be tested but I'll make a separate change in dev if you agree this is useful. 