### PR TITLE
Memory allocation optimization

### DIFF
--- a/src/Microsoft.AspNetCore.WebSockets.Protocol/Utilities.cs
+++ b/src/Microsoft.AspNetCore.WebSockets.Protocol/Utilities.cs
@@ -25,25 +25,28 @@ namespace Microsoft.AspNetCore.WebSockets.Protocol
             MaskInPlace(mask, ref maskOffset, data);
         }
 
+        public static void MaskInPlace(int mask, byte[] data, int dataStart, int dataCount)
+        {
+            int maskOffset = 0;
+            MaskInPlace(mask, ref maskOffset, data, dataStart, dataCount);
+        }
+
         public static void MaskInPlace(int mask, ref int maskOffset, ArraySegment<byte> data)
+        {
+            MaskInPlace(mask, ref maskOffset, data.Array, data.Offset, data.Count);
+        }
+
+        public static void MaskInPlace(int mask, ref int maskOffset, byte[] data, int dataStart, int dataCount)
         {
             if (mask == 0)
             {
                 return;
             }
 
-            byte[] maskBytes = new byte[]
+            int end = dataStart + dataCount;
+            for (int i = dataStart; i < end; i++)
             {
-                (byte)(mask >> 24),
-                (byte)(mask >> 16),
-                (byte)(mask >> 8),
-                (byte)mask,
-            };
-
-            int end = data.Offset + data.Count;
-            for (int i = data.Offset; i < end; i++)
-            {
-                data.Array[i] ^= maskBytes[maskOffset];
+                data[i] ^= (byte)(mask >> (24 - maskOffset * 8));
                 maskOffset = (maskOffset + 1) & 0x3; // fast % 4;
             }
         }

--- a/test/Microsoft.AspNetCore.WebSockets.Protocol.Test/UtilitiesTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.Protocol.Test/UtilitiesTests.cs
@@ -18,5 +18,26 @@ namespace Microsoft.AspNetCore.WebSockets.Protocol.Test
             Utilities.MaskInPlace(16843009, new ArraySegment<byte>(data));
             Assert.Equal(orriginal, data);
         }
+
+        [Theory]
+        [InlineData(0, 0, new byte[0])]
+        [InlineData(1, 1, new byte[] { 0x75 })]
+        [InlineData(2, 2, new byte[] { 0x75, 0x58 })]
+        [InlineData(3, 3, new byte[] { 0x75, 0x58, 0xEB })]
+        [InlineData(4, 0, new byte[] { 0x75, 0x58, 0xEB, 0xFF })]
+        [InlineData(5, 1, new byte[] { 0x75, 0x58, 0xEB, 0xFF, 0x73 })]
+        public void MaskInPlace(int bufferLength, int expectedMaskOffset, byte[] expectedOutput)
+        {
+            var random = new Random(1);
+            var buffer = new byte[bufferLength];
+            random.NextBytes(buffer);
+
+            const int mask = 864578941;         // This value has each of the four mask bytes different, so it makes bugs more visible
+            int maskOffset = 0;
+            Utilities.MaskInPlace(mask, ref maskOffset, new ArraySegment<byte>(buffer));
+
+            Assert.Equal(expectedMaskOffset, maskOffset);
+            Assert.Equal(expectedOutput, buffer);
+        }
     }
 }


### PR DESCRIPTION
First pass to optimize memory management.
Autobahn tests OK.

- Refactoring code to send frames in one unique method.
- Removing array allocation in `Utilities.MaskInPlane()`.
- Removing FrameHeader allocation (see #77).
- Removing calls to `GetNextMask()` if not necessary.

Pending:
- Still FrameHeader allocation on frame receive.
- Clean the FrameHeader code.