### PR TITLE
Increase .travis.yml consistency between repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,9 @@ addons:
     - libunwind8
     - zlib1g
 env:
-  - KOREBUILD_DNU_RESTORE_CORECLR=true
-install:
-  - curl -sSL https://github.com/libuv/libuv/archive/v1.4.2.tar.gz | tar zxfv - -C /tmp && cd /tmp/libuv-1.4.2/
-  - sh autogen.sh
-  - ./configure --prefix=$HOME/libuvinstall
-  - make
-  - make install
-  - export LD_LIBRARY_PATH="$HOME/libuvinstall/lib"
-  - cd $OLDPWD
-  - sudo pip install autobahntestsuite "six>=1.9.0"
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
 mono:
   - 4.0.5
 python:
@@ -37,5 +30,7 @@ branches:
     - /^(.*\/)?ci-.*$/
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl python; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
+install:
+  - sudo pip install autobahntestsuite "six>=1.9.0"
 script:
   - ./build.sh --quiet verify


### PR DESCRIPTION
- aspnet/Universe#349
- minimize `dotnet` setup time; no need for caching
- `KOREBUILD_DNU_RESTORE_CORECLR` env variable isn't used anymore
- no need for libuv v1.4.2 w/ current Kestrel packages