### PR TITLE
Fix NuGet project description ASP.NET 5 > Core

### DIFF
--- a/src/Microsoft.AspNetCore.WebSockets/project.json
+++ b/src/Microsoft.AspNetCore.WebSockets/project.json
@@ -9,7 +9,7 @@
     "xmlDoc": true,
     "allowUnsafe": true
   },
-  "description": "ASP.NET 5 web socket middleware for use on top of opaque servers.",
+  "description": "ASP.NET Core web socket middleware for use on top of opaque servers.",
   "packOptions": {
     "repository": {
       "type": "git",


### PR DESCRIPTION
changed leftover "ASP.NET 5" in project.json description to "ASP.NET Core"