### PR TITLE
port change from AutobahnTester in SignalR

### DIFF
--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 return client.GetAsync(result.ApplicationBaseUri);
-            }, logger, CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, result.HostShutdownToken).Token, retryCount: 5);
+            }, logger, CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, result.HostShutdownToken).Token);
             resp.EnsureSuccessStatusCode();
 
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
We increased the retry count (by just removing ours and using the default) because the app seems to be slow to start on macOS

/cc @pranavkm - This should fix the build