### PR TITLE
capture wstest log output

### DIFF
--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
 
                 // Run the test (write something to the console so people know this will take a while...)
                 _logger.LogInformation("Now launching Autobahn Test Suite. This will take a while.");
-                var exitCode = await Wstest.Default.ExecAsync("-m fuzzingclient -s " + specFile, cancellationToken);
+                var exitCode = await Wstest.Default.ExecAsync("-m fuzzingclient -s " + specFile, cancellationToken, _loggerFactory.CreateLogger("wstest"));
                 if (exitCode != 0)
                 {
                     throw new Exception("wstest failed");

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Executable.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Executable.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
 
         private void LogIfNotNull(Action<string, object[]> logger, string message, string data)
         {
-            if(!string.IsNullOrEmpty(data))
+            if (!string.IsNullOrEmpty(data))
             {
                 logger(message, new[] { data });
             }

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Executable.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Executable.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
 {
@@ -31,7 +32,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
             return null;
         }
 
-        public async Task<int> ExecAsync(string args, CancellationToken cancellationToken)
+        public async Task<int> ExecAsync(string args, CancellationToken cancellationToken, ILogger logger)
         {
             var process = new Process()
             {
@@ -40,6 +41,8 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
                     FileName = _path,
                     Arguments = args,
                     UseShellExecute = false,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
                 },
                 EnableRaisingEvents = true
             };
@@ -48,10 +51,23 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
             using (cancellationToken.Register(() => Cancel(process, tcs)))
             {
                 process.Exited += (_, __) => tcs.TrySetResult(process.ExitCode);
+                process.OutputDataReceived += (_, a) => LogIfNotNull(logger.LogInformation, "stdout: {0}", a.Data);
+                process.ErrorDataReceived += (_, a) => LogIfNotNull(logger.LogError, "stderr: {0}", a.Data);
 
                 process.Start();
 
+                process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
+
                 return await tcs.Task;
+            }
+        }
+
+        private void LogIfNotNull(Action<string, object[]> logger, string message, string data)
+        {
+            if(!string.IsNullOrEmpty(data))
+            {
+                logger(message, new[] { data });
             }
         }
 


### PR DESCRIPTION
this will make it easier to figure out what's wrong when 'wstest' fails to launch

This won't resolve the current OSX-Universe failure (which I believe to be transient) but it will give us more data when it happens again so we can properly de-flake it when it happens again.

/cc @jbagga @BrennanConroy @Tratcher 