### PR TITLE
Port test deflaking code from dev to patch/1.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,5 @@ branches:
     - /^(.*\/)?ci-.*$/
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl python; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
-install:
-  - pip install autobahntestsuite "six>=1.9.0"
 script:
   - ./build.sh --quiet verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ branches:
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl python; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 install:
-  - sudo pip install autobahntestsuite "six>=1.9.0"
+  - pip install autobahntestsuite "six>=1.9.0"
 script:
   - ./build.sh --quiet verify

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@ branches:
     - /^(.*\/)?ci-.*$/
 build_script:
   - build.cmd --quiet verify
-install:
-  - set PATH=C:\Python27\scripts;%PATH%
-  - pip install autobahntestsuite
 clone_depth: 1
 test: off
 deploy: off

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnExpectations.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnExpectations.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
 
         public AutobahnExpectations Fail(params string[] caseSpecs) => Expect(Expectation.Fail, caseSpecs);
         public AutobahnExpectations NonStrict(params string[] caseSpecs) => Expect(Expectation.NonStrict, caseSpecs);
-        public AutobahnExpectations OkOrNonStrict(params string[] caseSpecs) => Expect(Expectation.OkOrNonStrict, caseSpecs);
         public AutobahnExpectations OkOrFail(params string[] caseSpecs) => Expect(Expectation.OkOrFail, caseSpecs);
 
         public AutobahnExpectations Expect(Expectation expectation, params string[] caseSpecs)
@@ -61,21 +60,15 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
                             }
                             break;
                         case Expectation.Ok:
-                            if (!caseResult.BehaviorIs("OK"))
-                            {
-                                failures.AppendLine($"Case {serverResult.Name}:{caseResult.Name}. Expected 'OK', but got '{caseResult.ActualBehavior}'");
-                            }
-                            break;
-                        case Expectation.OkOrNonStrict:
                             if (!caseResult.BehaviorIs("NON-STRICT") && !caseResult.BehaviorIs("OK"))
                             {
                                 failures.AppendLine($"Case {serverResult.Name}:{caseResult.Name}. Expected 'NON-STRICT' or 'OK', but got '{caseResult.ActualBehavior}'");
                             }
                             break;
                         case Expectation.OkOrFail:
-                            if (!caseResult.BehaviorIs("FAILED") && !caseResult.BehaviorIs("OK"))
+                            if (!caseResult.BehaviorIs("NON-STRICT") && !caseResult.BehaviorIs("FAILED") && !caseResult.BehaviorIs("OK"))
                             {
-                                failures.AppendLine($"Case {serverResult.Name}:{caseResult.Name}. Expected 'FAILED' or 'OK', but got '{caseResult.ActualBehavior}'");
+                                failures.AppendLine($"Case {serverResult.Name}:{caseResult.Name}. Expected 'FAILED', 'NON-STRICT' or 'OK', but got '{caseResult.ActualBehavior}'");
                             }
                             break;
                         default:

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
@@ -128,7 +128,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 return client.GetAsync(result.ApplicationBaseUri);
-            }, logger, CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, result.HostShutdownToken).Token, retryCount: 5);
+            }, logger, CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, result.HostShutdownToken).Token);
             resp.EnsureSuccessStatusCode();
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Expectation.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Expectation.cs
@@ -5,7 +5,6 @@
         Fail,
         NonStrict,
         OkOrFail,
-        Ok,
-        OkOrNonStrict
+        Ok
     }
 }

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
@@ -65,14 +65,12 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest
                             // IIS Express tests are a bit flaky, some tests fail occasionally or get non-strict passes
                             // https://github.com/aspnet/WebSockets/issues/100
                             await tester.DeployTestAndAddToSpec(ServerType.IISExpress, ssl: false, environment: "ManagedSockets", cancellationToken: cts.Token, expectationConfig: expect => expect
-                                .OkOrFail(Enumerable.Range(1, 20).Select(i => $"5.{i}").ToArray()) // 5.* occasionally fail on IIS express
-                                .OkOrNonStrict("3.2", "3.3", "3.4", "4.1.3", "4.1.4", "4.1.5", "4.2.3", "4.2.4", "4.2.5", "5.15")); // These occasionally get non-strict results
+                                .OkOrFail(Enumerable.Range(1, 20).Select(i => $"5.{i}").ToArray())); // 5.* occasionally fail on IIS express
                         }
 
                         // WebListener occasionally gives a non-strict response on 3.2. IIS Express seems to have the same behavior. Wonder if it's related to HttpSys?
                         // For now, just allow the non-strict response, it's not a failure.
-                        await tester.DeployTestAndAddToSpec(ServerType.WebListener, ssl: false, environment: "ManagedSockets", cancellationToken: cts.Token, expectationConfig: expect => expect
-                            .OkOrNonStrict("3.2", "4.2.4"));
+                        await tester.DeployTestAndAddToSpec(ServerType.WebListener, ssl: false, environment: "ManagedSockets", cancellationToken: cts.Token);
                     }
                 }
 

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest
                             // IIS Express tests are a bit flaky, some tests fail occasionally or get non-strict passes
                             // https://github.com/aspnet/WebSockets/issues/100
                             await tester.DeployTestAndAddToSpec(ServerType.IISExpress, ssl: false, environment: "ManagedSockets", cancellationToken: cts.Token, expectationConfig: expect => expect
+                                .OkOrFail("2.6", "6.22.22") // Getting some transient failures on the CI for these. See https://github.com/aspnet/WebSockets/issues/152
                                 .OkOrFail(Enumerable.Range(1, 20).Select(i => $"5.{i}").ToArray())); // 5.* occasionally fail on IIS express
                         }
 

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
@@ -53,22 +53,13 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest
             {
                 await tester.DeployTestAndAddToSpec(ServerType.Kestrel, ssl: false, environment: "ManagedSockets", cancellationToken: cts.Token);
 
-                // Windows-only IIS tests, and Kestrel SSL tests (due to: https://github.com/aspnet/WebSockets/issues/102)
+                // Windows-only WebListener tests, and Kestrel SSL tests (due to: https://github.com/aspnet/WebSockets/issues/102)
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     await tester.DeployTestAndAddToSpec(ServerType.Kestrel, ssl: true, environment: "ManagedSockets", cancellationToken: cts.Token);
 
                     if (IsWindows8OrHigher())
                     {
-                        if (IsIISExpress10Installed())
-                        {
-                            // IIS Express tests are a bit flaky, some tests fail occasionally or get non-strict passes
-                            // https://github.com/aspnet/WebSockets/issues/100
-                            await tester.DeployTestAndAddToSpec(ServerType.IISExpress, ssl: false, environment: "ManagedSockets", cancellationToken: cts.Token, expectationConfig: expect => expect
-                                .OkOrFail("2.6", "6.22.22") // Getting some transient failures on the CI for these. See https://github.com/aspnet/WebSockets/issues/152
-                                .OkOrFail(Enumerable.Range(1, 20).Select(i => $"5.{i}").ToArray())); // 5.* occasionally fail on IIS express
-                        }
-
                         // WebListener occasionally gives a non-strict response on 3.2. IIS Express seems to have the same behavior. Wonder if it's related to HttpSys?
                         // For now, just allow the non-strict response, it's not a failure.
                         await tester.DeployTestAndAddToSpec(ServerType.WebListener, ssl: false, environment: "ManagedSockets", cancellationToken: cts.Token);

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
@@ -69,8 +69,10 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest
                                 .OkOrNonStrict("3.2", "3.3", "3.4", "4.1.3", "4.1.4", "4.1.5", "4.2.3", "4.2.4", "4.2.5", "5.15")); // These occasionally get non-strict results
                         }
 
+                        // WebListener occasionally gives a non-strict response on 3.2. IIS Express seems to have the same behavior. Wonder if it's related to HttpSys?
+                        // For now, just allow the non-strict response, it's not a failure.
                         await tester.DeployTestAndAddToSpec(ServerType.WebListener, ssl: false, environment: "ManagedSockets", cancellationToken: cts.Token, expectationConfig: expect => expect
-                            .OkOrNonStrict("4.2.4"));
+                            .OkOrNonStrict("3.2", "4.2.4"));
                     }
                 }
 


### PR DESCRIPTION
This ports the **test-only** changes from dev over to patch/1.1.3 to help deflake the tests.

@Eilon - Since this is test-only, is it OK to merge for patch or do we need approval?

/cc @pranavkm 

resolves #163 