### PR TITLE
remove integration test logging

### DIFF
--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
@@ -5,9 +5,9 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
-using Microsoft.AspNetCore.Server.IntegrationTesting.xunit;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.WebSockets.ConformanceTest


### PR DESCRIPTION
now that logging.testing has it

React to aspnet/Hosting#1039

GitHub messed up the previous PR #171 . So I had to reopen it.