### PR TITLE
restore override of Begin/EndRead

### DIFF
--- a/test/Microsoft.AspNetCore.WebSockets.Test/BufferStream.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.Test/BufferStream.cs
@@ -152,6 +152,71 @@ namespace Microsoft.AspNetCore.WebSockets.Test
             }
         }
 
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            // TODO: This option doesn't preserve the state object.
+            // return ReadAsync(buffer, offset, count);
+            return base.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            // return ((Task<int>)asyncResult).Result;
+            return base.EndRead(asyncResult);
+        }
+
+        public async override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if(_terminated)
+            {
+                return 0;
+            }
+
+            VerifyBuffer(buffer, offset, count, allowEmpty: false);
+            CancellationTokenRegistration registration = cancellationToken.Register(Abort);
+            await _readLock.WaitAsync(cancellationToken);
+            try
+            {
+                int totalRead = 0;
+                do
+                {
+                    // Don't drained buffered data on abort.
+                    CheckAborted();
+                    if (_topBuffer.Count <= 0)
+                    {
+                        byte[] topBuffer = null;
+                        while (!_bufferedData.TryDequeue(out topBuffer))
+                        {
+                            if (_disposed)
+                            {
+                                CheckAborted();
+                                // Graceful close
+                                return totalRead;
+                            }
+                            await WaitForDataAsync();
+                        }
+                        _topBuffer = new ArraySegment<byte>(topBuffer);
+                    }
+                    int actualCount = Math.Min(count, _topBuffer.Count);
+                    Buffer.BlockCopy(_topBuffer.Array, _topBuffer.Offset, buffer, offset, actualCount);
+                    _topBuffer = new ArraySegment<byte>(_topBuffer.Array,
+                        _topBuffer.Offset + actualCount,
+                        _topBuffer.Count - actualCount);
+                    totalRead += actualCount;
+                    offset += actualCount;
+                    count -= actualCount;
+                }
+                while (count > 0 && (_topBuffer.Count > 0 || _bufferedData.Count > 0));
+                // Keep reading while there is more data available and we have more space to put it in.
+                return totalRead;
+            }
+            finally
+            {
+                registration.Dispose();
+                _readLock.Release();
+            }
+        }
+
         // Write with count 0 will still trigger OnFirstWrite
         public override void Write(byte[] buffer, int offset, int count)
         {
@@ -176,6 +241,37 @@ namespace Microsoft.AspNetCore.WebSockets.Test
             {
                 _writeLock.Release();
             }
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            Write(buffer, offset, count);
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>(state);
+            tcs.TrySetResult(null);
+            IAsyncResult result = tcs.Task;
+            if (callback != null)
+            {
+                callback(result);
+            }
+            return result;
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            VerifyBuffer(buffer, offset, count, allowEmpty: true);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+                tcs.TrySetCanceled();
+                return tcs.Task;
+            }
+
+            Write(buffer, offset, count);
+            return Task.FromResult<object>(null);
         }
 
         private static void VerifyBuffer(byte[] buffer, int offset, int count, bool allowEmpty)

--- a/test/Microsoft.AspNetCore.WebSockets.Test/DuplexStream.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.Test/DuplexStream.cs
@@ -94,6 +94,31 @@ namespace Microsoft.AspNetCore.WebSockets.Test
             return ReadStream.Read(buffer, offset, count);
         }
 
+        public override int ReadByte()
+        {
+            return ReadStream.ReadByte();
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return ReadStream.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return ReadStream.EndRead(asyncResult);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return ReadStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return ReadStream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
 #endregion Read
 
 #region Write
@@ -101,6 +126,31 @@ namespace Microsoft.AspNetCore.WebSockets.Test
         public override void Write(byte[] buffer, int offset, int count)
         {
             WriteStream.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            WriteStream.WriteByte(value);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return WriteStream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            WriteStream.EndWrite(asyncResult);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return WriteStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return WriteStream.FlushAsync(cancellationToken);
         }
 
         public override void Flush()


### PR DESCRIPTION
I removed these when I was making the `netcoreapp2.0` changes, because they were `#if`ed out, but https://github.com/aspnet/BasicMiddleware/pull/228#discussion_r115050738 and https://github.com/aspnet/ResponseCaching/pull/121#discussion_r114929517 make me think that's wrong and these overrides **should** be present in the `netcoreapp2.0` version.