### PR TITLE
fix build by adding OutputType exe to test project

### DIFF
--- a/test/Microsoft.AspNetCore.WebSockets.Test/Microsoft.AspNetCore.WebSockets.Test.csproj
+++ b/test/Microsoft.AspNetCore.WebSockets.Test/Microsoft.AspNetCore.WebSockets.Test.csproj
@@ -5,6 +5,12 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+
+    <!--
+      Workaround for "Explicit RID still required for .NET Framework test projects" (https://github.com/dotnet/sdk/issues/909).
+      Remove when fixed.
+    -->
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.WebSockets.Test/Program.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.Test/Program.cs
@@ -1,0 +1,17 @@
+#if NET461
+using System;
+
+namespace Microsoft.AspNetCore.WebSockets.Test
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("This Program.Main is only here to work around https://github.com/dotnet/sdk/issues/909");
+        }
+    }
+}
+#elif NETCOREAPP2_0
+#else
+#error Target frameworks need to be updated
+#endif

--- a/test/Microsoft.AspNetCore.WebSockets.Test/Program.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.Test/Program.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 #if NET461
 using System;
 


### PR DESCRIPTION
continuing to work around https://github.com/dotnet/sdk/issues/909

Merging after AppVeyor and Travis runs to unblock build.