### PR TITLE
Upgrade TargetFramework in TestServer from 4.5 to 4.6.1

### DIFF
--- a/samples/TestServer/App.config
+++ b/samples/TestServer/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
 </configuration>

--- a/samples/TestServer/TestServer.csproj
+++ b/samples/TestServer/TestServer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestServer</RootNamespace>
     <AssemblyName>TestServer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
* Aligns with the rest of ASP.NET Core and removes the dependency on .NET 4.5 to build the WebSockets repo
* Addresses https://github.com/aspnet/WebSockets/issues/185