### PR TITLE
Force conformance tests to run on the CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,8 +12,8 @@ branches:
     - /release\/.*/
     - dev
     - /^(.*\/)?ci-.*$/
-# install:
-#   - ps: .\build\setup-wstest.ps1
+install:
+  - ps: .\build\setup-wstest.ps1
 build_script:
   - ps: .\run.ps1 default-build
 clone_depth: 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,12 +5,15 @@ environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    ASPNETCORE_WSTEST_PATH: "$(APPVEYOR_BUILD_FOLDER)/.virtualenv/bin/wstest.exe"
 branches:
   only:
     - master
     - /release\/.*/
     - dev
     - /^(.*\/)?ci-.*$/
+# install:
+#   - ps: .\build\setup-wstest.ps1
 build_script:
   - ps: .\run.ps1 default-build
 clone_depth: 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,8 @@ environment:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     ASPNETCORE_WSTEST_PATH: "$(APPVEYOR_BUILD_FOLDER)/.virtualenv/bin/wstest.exe"
+cache:
+  - vendor\VCForPython27.msi
 branches:
   only:
     - master

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    ASPNETCORE_WSTEST_PATH: "$(APPVEYOR_BUILD_FOLDER)/.virtualenv/bin/wstest.exe"
+    ASPNETCORE_WSTEST_PATH: "$(APPVEYOR_BUILD_FOLDER)/vendor/virtualenv/Scripts/wstest.exe"
 cache:
   - vendor\VCForPython27.msi
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ branches:
     - /release\/.*/
     - dev
     - /^(.*\/)?ci-.*$/
-install:
-  - ./build/setup-wstest.sh
+# install:
+#   - ./build/setup-wstest.sh
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ branches:
     - /release\/.*/
     - dev
     - /^(.*\/)?ci-.*$/
-# install:
-#   - ./build/setup-wstest.sh
+install:
+  - ./build/setup-wstest.sh
 script:
   - ./build.sh

--- a/build/setup-wstest.ps1
+++ b/build/setup-wstest.ps1
@@ -16,14 +16,16 @@ python --version
 pip install virtualenv
 
 # Make a virtualenv in .virtualenv
-virtualenv .virtualenv
+$VirtualEnvDir = Join-Path (Get-Location) ".virtualenv";
 
-.virtualenv/bin/python --version
-.virtualenv/bin/pip --version
+virtualenv $VirtualEnvDir
+
+& "$VirtualEnvDir\bin\python" --version
+& "$VirtualEnvDir\bin\pip" --version
 
 # Install autobahn into the virtualenv
-.virtualenv/bin/pip install autobahntestsuite
+& "$VirtualEnvDir\bin\pip" install autobahntestsuite
 
 # We're done. The travis config has already established the path to WSTest should be within the virtualenv.
-Get-ChildItem .virtualenv/bin
-.virtualenv/bin/wstest --version
+Get-ChildItem .$VirtualEnvDir/bin
+& "$VirtualEnvDir\bin\wstest" --version

--- a/build/setup-wstest.ps1
+++ b/build/setup-wstest.ps1
@@ -49,5 +49,4 @@ virtualenv $VirtualEnvDir
 # Install autobahn into the virtualenv
 & "$ScriptsDir\pip" install autobahntestsuite
 
-$Ver = & "$WsTest" --version
-Write-Host "Using wstest $Ver"
+Write-Host "Using wstest from: '$WsTest'"

--- a/build/setup-wstest.ps1
+++ b/build/setup-wstest.ps1
@@ -7,7 +7,7 @@ if(!(Test-Path $VendorDir)) {
     mkdir $VendorDir
 }
 
-$VirtualEnvDir = Join-Path (Get-Location) "virtualenv";
+$VirtualEnvDir = Join-Path $VendorDir "virtualenv";
 $ScriptsDir = Join-Path $VirtualEnvDir "Scripts"
 $WsTest = Join-Path $ScriptsDir "wstest.exe"
 

--- a/build/setup-wstest.ps1
+++ b/build/setup-wstest.ps1
@@ -1,0 +1,29 @@
+function has($cmd) { !!(Get-Command $cmd -ErrorAction SilentlyContinue) }
+
+# Install Python
+if(!(has python)) {
+    choco install python2
+}
+
+if(!(has python)) {
+    throw "Failed to install python2"
+}
+
+# Print python version
+python --version
+
+# Install virtualenv
+pip install virtualenv
+
+# Make a virtualenv in .virtualenv
+virtualenv .virtualenv
+
+.virtualenv/bin/python --version
+.virtualenv/bin/pip --version
+
+# Install autobahn into the virtualenv
+.virtualenv/bin/pip install autobahntestsuite
+
+# We're done. The travis config has already established the path to WSTest should be within the virtualenv.
+Get-ChildItem .virtualenv/bin
+.virtualenv/bin/wstest --version

--- a/build/setup-wstest.ps1
+++ b/build/setup-wstest.ps1
@@ -9,9 +9,6 @@ if(!(has python)) {
     throw "Failed to install python2"
 }
 
-# Print python version
-python --version
-
 # Install virtualenv
 pip install virtualenv
 
@@ -20,12 +17,12 @@ $VirtualEnvDir = Join-Path (Get-Location) ".virtualenv";
 
 virtualenv $VirtualEnvDir
 
-& "$VirtualEnvDir\bin\python" --version
-& "$VirtualEnvDir\bin\pip" --version
+& "$VirtualEnvDir\Scripts\python" --version
+& "$VirtualEnvDir\Scripts\pip" --version
 
 # Install autobahn into the virtualenv
-& "$VirtualEnvDir\bin\pip" install autobahntestsuite
+& "$VirtualEnvDir\Scripts\pip" install autobahntestsuite
 
 # We're done. The travis config has already established the path to WSTest should be within the virtualenv.
 Get-ChildItem .$VirtualEnvDir/bin
-& "$VirtualEnvDir\bin\wstest" --version
+& "$VirtualEnvDir\Scripts\wstest" --version

--- a/build/setup-wstest.ps1
+++ b/build/setup-wstest.ps1
@@ -1,5 +1,33 @@
 function has($cmd) { !!(Get-Command $cmd -ErrorAction SilentlyContinue) }
 
+# Download VCForPython27 if necessary
+$VendorDir = Join-Path (Get-Location) "vendor"
+
+if(!(Test-Path $VendorDir)) {
+    mkdir $VendorDir
+}
+
+$VirtualEnvDir = Join-Path (Get-Location) "virtualenv";
+$ScriptsDir = Join-Path $VirtualEnvDir "Scripts"
+$WsTest = Join-Path $ScriptsDir "wstest.exe"
+
+$VCPythonMsi = Join-Path $VendorDir "VCForPython27.msi"
+if(!(Test-Path $VCPythonMsi)) {
+    Write-Host "Downloading VCForPython27.msi"
+    Invoke-WebRequest -Uri https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi -OutFile "$VCPythonMsi"
+}
+else {
+    Write-Host "Using VCForPython27.msi from Cache"
+}
+
+# Install VCForPython27
+Write-Host "Installing VCForPython27"
+
+# Launch this way to ensure we wait for msiexec to complete. It's a Windows app so it won't block the console by default.
+Start-Process msiexec "/i","$VCPythonMsi","/qn","/quiet","/norestart" -Wait
+
+Write-Host "Installed VCForPython27"
+
 # Install Python
 if(!(has python)) {
     choco install python2
@@ -13,16 +41,13 @@ if(!(has python)) {
 pip install virtualenv
 
 # Make a virtualenv in .virtualenv
-$VirtualEnvDir = Join-Path (Get-Location) ".virtualenv";
-
 virtualenv $VirtualEnvDir
 
-& "$VirtualEnvDir\Scripts\python" --version
-& "$VirtualEnvDir\Scripts\pip" --version
+& "$ScriptsDir\python" --version
+& "$ScriptsDir\pip" --version
 
 # Install autobahn into the virtualenv
-& "$VirtualEnvDir\Scripts\pip" install autobahntestsuite
+& "$ScriptsDir\pip" install autobahntestsuite
 
-# We're done. The travis config has already established the path to WSTest should be within the virtualenv.
-Get-ChildItem .$VirtualEnvDir/bin
-& "$VirtualEnvDir\Scripts\wstest" --version
+$Ver = & "$WsTest" --version
+Write-Host "Using wstest $Ver"

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Executable.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Executable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Wstest.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Wstest.cs
@@ -10,11 +10,20 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
     {
         private static Lazy<Wstest> _instance = new Lazy<Wstest>(Create);
 
+        public static readonly string DefaultLocation = LocateWstest();
+
         public static Wstest Default => _instance.Value;
 
         public Wstest(string path) : base(path) { }
 
         private static Wstest Create()
+        {
+            var location = LocateWstest();
+
+            return (location == null || !File.Exists(location)) ? null : new Wstest(location);
+        }
+
+        private static string LocateWstest()
         {
             var location = Environment.GetEnvironmentVariable("ASPNETCORE_WSTEST_PATH");
             if (string.IsNullOrEmpty(location))
@@ -22,7 +31,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
                 location = Locate("wstest");
             }
 
-            return (location == null || !File.Exists(location)) ? null : new Wstest(location);
+            return location;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Wstest.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Wstest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
                 location = Locate("wstest");
             }
 
-            return (location == null && !File.Exists(location)) ? null : new Wstest(location);
+            return (location == null || !File.Exists(location)) ? null : new Wstest(location);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Wstest.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Wstest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
                 location = Locate("wstest");
             }
 
-            return (location == null && File.Exists(location)) ? null : new Wstest(location);
+            return (location == null && !File.Exists(location)) ? null : new Wstest(location);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Wstest.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/Wstest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.IO;
 
 namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
 {
@@ -20,7 +21,8 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
             {
                 location = Locate("wstest");
             }
-            return location == null ? null : new Wstest(location);
+
+            return (location == null && File.Exists(location)) ? null : new Wstest(location);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.WebSockets.ConformanceTest
@@ -27,6 +28,11 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest
         [SkipIfWsTestNotPresent]
         public async Task AutobahnTestSuite()
         {
+            // If we're on CI, we want to actually fail if WsTest isn't installed, rather than just skipping the test
+            // The SkipIfWsTestNotPresent attribute ensures that this test isn't skipped on CI, so we just need to check that Wstest is present
+            // And we use Assert.True to provide an error message
+            Assert.True(Wstest.Default != null, "The 'wstest' executable (Autobahn WebSockets Test Suite) could not be found on the PATH. Run the Build Agent setup scripts to install it or see https://github.com/crossbario/autobahn-testsuite for instructions on manual installation.");
+
             using (StartLog(out var loggerFactory))
             {
                 var logger = loggerFactory.CreateLogger<AutobahnTests>();

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/AutobahnTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest
             // If we're on CI, we want to actually fail if WsTest isn't installed, rather than just skipping the test
             // The SkipIfWsTestNotPresent attribute ensures that this test isn't skipped on CI, so we just need to check that Wstest is present
             // And we use Assert.True to provide an error message
-            Assert.True(Wstest.Default != null, "The 'wstest' executable (Autobahn WebSockets Test Suite) could not be found on the PATH. Run the Build Agent setup scripts to install it or see https://github.com/crossbario/autobahn-testsuite for instructions on manual installation.");
+            Assert.True(Wstest.Default != null, $"The 'wstest' executable (Autobahn WebSockets Test Suite) could not be found at '{Wstest.DefaultLocation}'. Run the Build Agent setup scripts to install it or see https://github.com/crossbario/autobahn-testsuite for instructions on manual installation.");
 
             using (StartLog(out var loggerFactory))
             {

--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/SkipIfWsTestNotPresentAttribute.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/SkipIfWsTestNotPresentAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn;
 
@@ -7,7 +7,12 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class SkipIfWsTestNotPresentAttribute : Attribute, ITestCondition
     {
-        public bool IsMet => Wstest.Default != null;
+        public bool IsMet => IsOnCi || Wstest.Default != null;
         public string SkipReason => "Autobahn Test Suite is not installed on the host machine.";
+
+        private static bool IsOnCi =>
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_VERSION")) ||
+            string.Equals(Environment.GetEnvironmentVariable("TRAVIS"), "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(Environment.GetEnvironmentVariable("APPVEYOR"), "true", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Right now, if wstest isn't installed, the conformance tests simply don't run. This is good for community and infrequent dev usage, but the CI really needs to run them every time. This change forces the test to run when in our CI environment and will fail with a useful error if wstest isn't installed.

WIP because I disabled Travis installing wstest to verify this works. Also, I need to add the install script for AppVeyor (it's not essential but it's useful to run the tests on all our environments)