### PR TITLE
Remove buffer size argument

### DIFF
--- a/src/Microsoft.AspNetCore.WebSockets/WebSocketMiddleware.cs
+++ b/src/Microsoft.AspNetCore.WebSockets/WebSocketMiddleware.cs
@@ -119,10 +119,7 @@ namespace Microsoft.AspNetCore.WebSockets
 
                 Stream opaqueTransport = await _upgradeFeature.UpgradeAsync(); // Sets status code to 101
 
-                // Allocate a buffer for receive (default is 4k)
-                var buffer = new byte[receiveBufferSize];
-
-                return WebSocketProtocol.CreateFromStream(opaqueTransport, isServer: true, subProtocol: subProtocol, keepAliveInterval: keepAliveInterval, buffer: buffer);
+                return WebSocketProtocol.CreateFromStream(opaqueTransport, isServer: true, subProtocol: subProtocol, keepAliveInterval: keepAliveInterval);
             }
         }
     }


### PR DESCRIPTION
- We're removing the buffer argument from the API as a result of a mini review. This is a pre-emptive reaction to avoid breakage when the change comes in.

See https://github.com/dotnet/corefx/pull/28649