### PR TITLE
 Enable tests on 2.1 for Win7

### DIFF
--- a/test/Microsoft.AspNetCore.WebSockets.Test/WebSocketMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.Test/WebSocketMiddlewareTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.WebSockets.Test
 #elif NETCOREAPP2_1
     // ClientWebSocket has added support for WebSockets on Win7.
 #else
-    Unknown TFM
+#error Unknown TFM
 #endif
     public class WebSocketMiddlewareTests : LoggedTest
     {


### PR DESCRIPTION
Kestrel has always supported WebSockets on Win7 but in prior versions we didn't have a client to test with. In 2.1 ClientWebSocket has added support for WebSockets on Win7 so we can now enable these tests. Found while debugging Win7 Kestrel failures.

Also removed an obsolete workaround in program.cs.