### PR TITLE
Work around HttpClient TLS regression

### DIFF
--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -160,6 +161,8 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
             cancellationToken.ThrowIfCancellationRequested();
 
             var handler = new HttpClientHandler();
+            // Win7 HttpClient on NetCoreApp2.1 defaults to TLS 1.0 and won't connect to Kestrel. https://github.com/dotnet/corefx/issues/28733
+            handler.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11;
             if (ssl)
             {
                 // Don't take this out of the "if(ssl)". If we set it on some platforms, it crashes


### PR DESCRIPTION
@muratg we're still good to fix failing tests in release/2.1 yes?

This test always fails on Win7/2008R2 due to the new managed HttpClient. See https://github.com/dotnet/corefx/issues/28733 and http://aspnetci/project.html?projectId=XPlat&testNameId=-5773695069337434026&tab=testDetails