### PR TITLE
Fix TLS versions for Mac

### DIFF
--- a/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
+++ b/test/Microsoft.AspNetCore.WebSockets.ConformanceTest/Autobahn/AutobahnTester.cs
@@ -162,7 +162,9 @@ namespace Microsoft.AspNetCore.WebSockets.ConformanceTest.Autobahn
 
             var handler = new HttpClientHandler();
             // Win7 HttpClient on NetCoreApp2.1 defaults to TLS 1.0 and won't connect to Kestrel. https://github.com/dotnet/corefx/issues/28733
-            handler.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11;
+            // Mac HttpClient on NetCoreApp2.0 doesn't alow you to set some combinations.
+            // https://github.com/dotnet/corefx/blob/586cffcdfdf23ad6c193a4bf37fce88a1bf69508/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.OSX.cs#L104-L106
+            handler.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
             if (ssl)
             {
                 // Don't take this out of the "if(ssl)". If we set it on some platforms, it crashes


### PR DESCRIPTION
Followup to https://github.com/aspnet/WebSockets/pull/235. Apparently Mac doesn't allow you to specify two different TLS versions. You can specify one or all three but not combinations of two.

https://github.com/dotnet/corefx/blob/586cffcdfdf23ad6c193a4bf37fce88a1bf69508/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.OSX.cs#L104-L106

http://aspnetci/viewLog.html?buildId=439124&tab=buildResultsDiv&buildTypeId=Releases_21Public_OsxUniverse

This also should have failed for Linux but didn't for some reason.
https://github.com/dotnet/corefx/blob/586cffcdfdf23ad6c193a4bf37fce88a1bf69508/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs#L212-L214