### PR TITLE
fix wstest on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 os:
 - linux
 - osx
-osx_image: xcode9
+osx_image: xcode9.3
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
 os:
 - linux
 - osx
-osx_image: xcode8.2
+osx_image: xcode9
 addons:
   apt:
     packages:

--- a/build/setup-wstest.sh
+++ b/build/setup-wstest.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# We have to update python on macOS to ensure we have one that supports TLS > 1.2
+# We have to update pip on macOS to ensure we have one that supports TLS > 1.2
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    # Install python
-    brew update > /dev/null
-    brew install python
+    curl https://bootstrap.pypa.io/get-pip.py | python
 fi
 
 type -p python

--- a/build/setup-wstest.sh
+++ b/build/setup-wstest.sh
@@ -13,9 +13,6 @@ cd ..
 # Make a virtualenv
 python ./.python/virtualenv-15.1.0/virtualenv.py .virtualenv
 
-# Check TLS version
-.virtualenv/bin/python -c "import urllib2,json; print(json.loads(urllib2.urlopen('https://www.howsmyssl.com/a/check').read())['tls_version'])"
-
 .virtualenv/bin/python --version
 .virtualenv/bin/pip --version
 

--- a/build/setup-wstest.sh
+++ b/build/setup-wstest.sh
@@ -16,12 +16,6 @@ python ./.python/virtualenv-15.1.0/virtualenv.py .virtualenv
 # Check TLS version
 .virtualenv/bin/python -c "import urllib2,json; print(json.loads(urllib2.urlopen('https://www.howsmyssl.com/a/check').read())['tls_version'])"
 
-# We have to update pip on macOS to ensure we have one that supports TLS > 1.2.
-# We do the update INSIDE the virtualenv (for permission reasons).
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    curl https://bootstrap.pypa.io/get-pip.py | .virtualenv/bin/python
-fi
-
 .virtualenv/bin/python --version
 .virtualenv/bin/pip --version
 

--- a/build/setup-wstest.sh
+++ b/build/setup-wstest.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# We have to update pip on macOS to ensure we have one that supports TLS > 1.2
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    curl https://bootstrap.pypa.io/get-pip.py | python
-fi
-
 type -p python
 python --version
 
@@ -17,6 +12,12 @@ cd ..
 
 # Make a virtualenv
 python ./.python/virtualenv-15.1.0/virtualenv.py .virtualenv
+
+# We have to update pip on macOS to ensure we have one that supports TLS > 1.2.
+# We do the update INSIDE the virtualenv (for permission reasons).
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    curl https://bootstrap.pypa.io/get-pip.py | .virtualenv/bin/python
+fi
 
 .virtualenv/bin/python --version
 .virtualenv/bin/pip --version

--- a/build/setup-wstest.sh
+++ b/build/setup-wstest.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
-if ! type -p python > /dev/null; then
-    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-        # Install python
-        brew update > /dev/null
-        brew install python
-    fi
+# We have to update python on macOS to ensure we have one that supports TLS > 1.2
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    # Install python
+    brew update > /dev/null
+    brew install python
 fi
 
 type -p python

--- a/build/setup-wstest.sh
+++ b/build/setup-wstest.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    # Install python
-    brew update > /dev/null
-    brew install python
+if ! type -p python > /dev/null; then
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        # Install python
+        brew update > /dev/null
+        brew install python
+    fi
 fi
 
 type -p python

--- a/build/setup-wstest.sh
+++ b/build/setup-wstest.sh
@@ -13,6 +13,9 @@ cd ..
 # Make a virtualenv
 python ./.python/virtualenv-15.1.0/virtualenv.py .virtualenv
 
+# Check TLS version
+.virtualenv/bin/python -c "import urllib2,json; print(json.loads(urllib2.urlopen('https://www.howsmyssl.com/a/check').read())['tls_version'])"
+
 # We have to update pip on macOS to ensure we have one that supports TLS > 1.2.
 # We do the update INSIDE the virtualenv (for permission reasons).
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/build/setup-wstest.sh
+++ b/build/setup-wstest.sh
@@ -14,7 +14,7 @@ python --version
 # Install local virtualenv
 mkdir .python
 cd .python
-curl -O https://pypi.python.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz
+curl -OL https://pypi.python.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz
 tar xf virtualenv-15.1.0.tar.gz
 cd ..
 


### PR DESCRIPTION
Having build buds review since this is more about build scripts.

PyPI (the package index for Python) dropped support for TLS < 1.2 recently which broke our script for installing `wstest`. Turns out the built-in python on macOS versions **below** 10.13 doesn't support TLS 1.2. This updates the image to point at `xcode9.3` which is macOS 10.13 (High Sierra) which resolves this issue.

This does not affect our internal builds or .NET CI AFAICT, it's just that we need to build on a higher version of macOS in order to be able to download the dependencies. Our CI machines have `wstest` preinstalled and don't have to do these steps at all. I'm not at all worried about losing downlevel coverage here as macOS isn't a primary production server scenario (and this is just travis)

Fixes aspnet/Home#3074