### PR TITLE
Write websocket header directly to the repsonse headers

### DIFF
--- a/src/Microsoft.AspNetCore.WebSockets/Internal/HandshakeHelpers.cs
+++ b/src/Microsoft.AspNetCore.WebSockets/Internal/HandshakeHelpers.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.WebSockets.Internal
 {
@@ -63,14 +64,14 @@ namespace Microsoft.AspNetCore.WebSockets.Internal
             return validConnection && validUpgrade && validVersion && validKey;
         }
 
-        public static IEnumerable<KeyValuePair<string, string>> GenerateResponseHeaders(string key, string subProtocol)
+        public static void GenerateResponseHeaders(string key, string subProtocol, IHeaderDictionary headers)
         {
-            yield return new KeyValuePair<string, string>(Constants.Headers.Connection, Constants.Headers.ConnectionUpgrade);
-            yield return new KeyValuePair<string, string>(Constants.Headers.Upgrade, Constants.Headers.UpgradeWebSocket);
-            yield return new KeyValuePair<string, string>(Constants.Headers.SecWebSocketAccept, CreateResponseKey(key));
+            headers[Constants.Headers.Connection] = Constants.Headers.ConnectionUpgrade;
+            headers[Constants.Headers.Upgrade] = Constants.Headers.UpgradeWebSocket;
+            headers[Constants.Headers.SecWebSocketAccept] = CreateResponseKey(key);
             if (!string.IsNullOrWhiteSpace(subProtocol))
             {
-                yield return new KeyValuePair<string, string>(Constants.Headers.SecWebSocketProtocol, subProtocol);
+                headers[Constants.Headers.SecWebSocketProtocol] = subProtocol;
             }
         }
 

--- a/src/Microsoft.AspNetCore.WebSockets/WebSocketMiddleware.cs
+++ b/src/Microsoft.AspNetCore.WebSockets/WebSocketMiddleware.cs
@@ -155,11 +155,7 @@ namespace Microsoft.AspNetCore.WebSockets
 
                 string key = string.Join(", ", _context.Request.Headers[Constants.Headers.SecWebSocketKey]);
 
-                var responseHeaders = HandshakeHelpers.GenerateResponseHeaders(key, subProtocol);
-                foreach (var headerPair in responseHeaders)
-                {
-                    _context.Response.Headers[headerPair.Key] = headerPair.Value;
-                }
+                HandshakeHelpers.GenerateResponseHeaders(key, subProtocol, _context.Response.Headers);
 
                 Stream opaqueTransport = await _upgradeFeature.UpgradeAsync(); // Sets status code to 101
 


### PR DESCRIPTION
Small improvement to not create a temporary enumerator while generating the response headers.